### PR TITLE
Diff child folders 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ s3diff({
   remote: {
     bucket: 'name-of-s3-bucket',
     prefix: 'name/of/folder/to/sync/on/s3'
-  }
+  },
+  // If recursive flag is set to true, s3-diff will recursively diff child
+  // folders as well as the top level folder.
+  recursive: false
 }, function (err, data) {
   // data is an object with the following properties:
   //  changed: Files that have been changed - files that exists in both s3 & locally but are out of sync

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function localFiles (opts) {
              arr.push(file.replace(opts.local + '/', ''));
            }
            return arr;
-         }, []);
+         }, [])
       );
     });
   };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (opts, cb) {
       );
     } ]
   }, function (err, results) {
-    cb(err, results && formatResults(results));
+    cb(err, results.localFiles && results.s3Files && formatResults(results));
   });
 };
 
@@ -70,6 +70,7 @@ function s3Files (s3, opts) {
     };
 
     s3.listObjects(params, function (err, data) {
+      if(err){return cb(err);}
       cb(err, data.Contents && formatDataContents(opts.remote.prefix, data.Contents));
     });
   };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var intersection = require('lodash.intersection');
 var difference = require('lodash.difference');
 var auto = require('run-auto');
 var glob = require('glob');
+var path = require('path');
 
 module.exports = function (opts, cb) {
   var s3 = new AWS.S3(opts.aws);
@@ -52,7 +53,7 @@ function localFiles (opts) {
       cb(err,
         files.reduce(function (arr, file) {
           if (fs.statSync(file).isFile()) {
-            arr.push(file.replace(opts.local + '/', ''));
+            arr.push(path.relative(opts.local, file));
           }
           return arr;
         }, [])

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function s3Files (s3, opts) {
 function formatDataContents (prefix, contents) {
   return contents.map(function (obj) {
     return {
-      key: obj.Key /*.slice(prefix.length + 1)*/, //TODO do this conditionally
+      key: prefix ? obj.Key.slice(prefix.length + 1) : obj.Key,
       etag: obj.ETag
     };
   });

--- a/index.js
+++ b/index.js
@@ -47,30 +47,15 @@ function formatResults (results) {
 }
 
 function localFiles (opts) {
-  //TODO add globbing
   return function (cb) {
-
-    // fs.readdir(opts.local, function (err, files) {
-    //   if (err && err.code === 'ENOENT') {
-    //     err = null;
-    //     files = [];
-    //   }
-    //   cb(err, files);
-    // });
     glob(opts.local + "/**/*", function (err, files) {
-      var a = files.reduce(function(arr, file){
-          if(fs.statSync(file).isFile()){
-            arr.push(file.replace(opts.local + '/', ''));
-          }
-          return arr;
-        }, []);
-
       cb(err,
-        files.map(function(file){
-          if(fs.statSync(file).isFile()){
-            return file.replace(opts.local + '/', '');
-          }
-        })
+        files.reduce(function(arr, file){
+           if(fs.statSync(file).isFile()){
+             arr.push(file.replace(opts.local + '/', ''));
+           }
+           return arr;
+         }, []);
       );
     });
   };
@@ -92,7 +77,7 @@ function s3Files (s3, opts) {
 function formatDataContents (prefix, contents) {
   return contents.map(function (obj) {
     return {
-      key: obj.Key /*.slice(prefix.length + 1)*/,
+      key: obj.Key /*.slice(prefix.length + 1)*/, //TODO do this conditionally
       etag: obj.ETag
     };
   });

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var getChanged = require('./lib/changed');
 var intersection = require('lodash.intersection');
 var difference = require('lodash.difference');
 var auto = require('run-auto');
-var glob = require("glob");
+var glob = require('glob');
 
 module.exports = function (opts, cb) {
   var s3 = new AWS.S3(opts.aws);
@@ -48,14 +48,14 @@ function formatResults (results) {
 
 function localFiles (opts) {
   return function (cb) {
-    glob(opts.local + "/**/*", function (err, files) {
+    glob(opts.local + '/**/*', function (err, files) {
       cb(err,
-        files.reduce(function(arr, file){
-           if(fs.statSync(file).isFile()){
-             arr.push(file.replace(opts.local + '/', ''));
-           }
-           return arr;
-         }, [])
+        files.reduce(function (arr, file) {
+          if (fs.statSync(file).isFile()) {
+            arr.push(file.replace(opts.local + '/', ''));
+          }
+          return arr;
+        }, [])
       );
     });
   };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/micnews/s3-diff#readme",
   "dependencies": {
     "aws-sdk": "^2.2.4",
+    "glob": "^7.0.5",
     "lodash.difference": "^3.2.2",
     "lodash.intersection": "^3.2.0",
     "run-auto": "^1.1.3"


### PR DESCRIPTION
- Adds file globbing to local directory to allow diff of files located within child folders

I ran into a problem where I wanted to watch a folder, and all of its subfolders for changes. This allows me to make only one call to s3-diff. 

I was scratching my head to figure out how I was going to avoid large uploads every time I wanted to sync to s3. Thanks for your work! 
